### PR TITLE
Default pre_select to empty string

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -39,7 +39,7 @@ class NewsSkill(MycroftSkill):
 
     @property
     def url_rss(self):
-        pre_select = self.settings.get("pre_select")
+        pre_select = self.settings.get("pre_select", "")
         url_rss = self.settings.get("url_rss")
         if "not_set" in pre_select:
             # Use a custom RSS URL


### PR DESCRIPTION
This bypasses issue when the setting is read as None. Resolves issue #14.