### PR TITLE
Feature/juhi24 better rss support

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -60,8 +60,19 @@ class NewsSkill(MycroftSkill):
             wait_while_speaking()
 
             # After the intro, start the news stream
+            i = 0
+            found_audio = False
+            # select first link to an audio file
+            for link in data['entries'][0]['links']:
+                if 'audio' in link['type']:
+                    found_audio = True
+                    break
+                i = i+1
+            if not found_audio:
+                # fall back to using first link
+                i = 0
             url = re.sub('https', 'http',
-                         data['entries'][0]['links'][0]['href'])
+                         data['entries'][0]['links'][i]['href'])
             # if audio service module is available use it
             if self.audioservice:
                 self.audioservice.play(url, message.data['utterance'])

--- a/__init__.py
+++ b/__init__.py
@@ -59,17 +59,17 @@ class NewsSkill(MycroftSkill):
             self.speak_dialog('news')
             wait_while_speaking()
 
-            # After the intro, start the news stream
+            # After the intro, find and start the news stream
             i = 0
             found_audio = False
-            # select first link to an audio file
+            # select the first link to an audio file
             for link in data['entries'][0]['links']:
                 if 'audio' in link['type']:
                     found_audio = True
                     break
                 i = i+1
             if not found_audio:
-                # fall back to using first link
+                # fall back to using the first link in the entry
                 i = 0
             url = re.sub('https', 'http',
                          data['entries'][0]['links'][i]['href'])

--- a/__init__.py
+++ b/__init__.py
@@ -64,19 +64,16 @@ class NewsSkill(MycroftSkill):
             wait_while_speaking()
 
             # After the intro, find and start the news stream
-            i = 0
-            found_audio = False
-            # select the first link to an audio file
+			# select the first link to an audio file
             for link in data['entries'][0]['links']:
                 if 'audio' in link['type']:
-                    found_audio = True
+                    media = link['href']
                     break
-                i = i+1
-            if not found_audio:
+            else:
                 # fall back to using the first link in the entry
-                i = 0
-            url = re.sub('https', 'http',
-                         data['entries'][0]['links'][i]['href'])
+                media = data['entries'][0]['links'][0]['href']
+            url = re.sub('https', 'http', media)
+
             # if audio service module is available use it
             if self.audioservice:
                 self.audioservice.play(url, message.data['utterance'])


### PR DESCRIPTION
Moving PR #17 to the 18.02 branch.

From the original PR:
"The code assumed the audio to be found in the first link of an rss entry. This is not the case for many news feeds (e.g. https://feeds.yle.fi/areena/v1/series/1-1440981.rss). Now it first sees if some of the links is an audio file. If not, it falls back to the previous functionality of picking the first link."

I've also added the suggested refactoring.