### PR TITLE
Create Padatious "Play the news" intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 ## Hourly News
-Plays the latest news report
+Listen to the latest news report from your favorite broadcast
 
-## Description 
-Plays the latest news from a configurable RSS based audio feed.  
-By default the NPR hourly news broadcast is used, but you can chose
-from other news feeds including the BBC, AP, CBC.ca, CNN,
-PBS or Fox.  See the setting at [home.mycroft.ai](https://home.mycroft.ai/#/skill).
+## Description
+Play the latest news from an RSS audio feed.  The National Public Radio (NPR)
+Hourly News is the default feed, or you can chose 
+from the BBC, Associated Press, CBC.ca, CNN, PBS or 
+Fox.  Select your favorite at:  
+[home.mycroft.ai](https://home.mycroft.ai/#/skill).
 
-## Examples 
+## Examples
 * "Play the news"
 * "Tell me the news"
 * "What's the latest news"

--- a/__init__.py
+++ b/__init__.py
@@ -17,6 +17,7 @@ from os.path import dirname
 import re
 
 from adapt.intent import IntentBuilder
+from mycroft import intent_file_handler
 from mycroft.skills.core import MycroftSkill, intent_handler
 from mycroft.audio import wait_while_speaking
 from mycroft.util.log import LOG
@@ -52,6 +53,13 @@ class NewsSkill(MycroftSkill):
             url_rss = self.config['url_rss']
 
         return url_rss
+
+
+    # Explict Padatious intent handler for "Play the news" to allow
+    # an override of the various music Adapt intents that use "Play"
+    @intent_file_handler('PlayNews.intent')
+    def handle_playnews(self, message):
+        self.handle_intent(message) 
 
     @intent_handler(IntentBuilder("").require("Play").require("News"))
     def handle_intent(self, message):

--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -1,5 +1,6 @@
 {
  "name": "Mycroft News Player",
+ "color": "#22a7f0",
  "skillMetadata": {
         "sections": [
             {

--- a/vocab/en-us/PlayNews.intent
+++ b/vocab/en-us/PlayNews.intent
@@ -1,0 +1,2 @@
+play (the|) news
+play npr news


### PR DESCRIPTION
Provide a Padatious intent for the phrase "play the news".  This is
a stop-gap measure to handle the overloaded "play" term which is
being gobbled up by some of the media skills, particularly Spotify.

Also refined the README and added the Mycroft branding color for
the skill settings block.