### PR TITLE
prevent matching 'whats today'

### DIFF
--- a/vocab/en-us/PlayTheNews.intent
+++ b/vocab/en-us/PlayTheNews.intent
@@ -1,5 +1,5 @@
 news (briefing|)
 (what is|what's) new
 brief me
-what's today's (news|) (briefing|)
-(what are|what's) today's headlines
+(what's|what is) today's (news|briefing)
+(what are|what's|what is) today's headlines


### PR DESCRIPTION
"What's today" was hitting the play the news intent instead of allowing the date-time skill to report the current date.