### PR TITLE
add pending vk step until included in core

### DIFF
--- a/test/behave/steps/news_steps.py
+++ b/test/behave/steps/news_steps.py
@@ -66,3 +66,37 @@ def then_playback_stop(context):
 @then('"mycroft-news" should pause playing')
 def then_playback_pause(context):
     wait_for_service_message(context, 'pause')
+
+# TODO remove from Skill once included in Mycroft-core
+def then_wait_fail(msg_type, criteria_func, context, timeout=10):
+    """Wait for a specified time, failing if criteria is fulfilled.
+
+    Arguments:
+        msg_type: message type to watch
+        criteria_func: Function to determine if a message fulfilling the
+                       test case has been found.
+        context: behave context
+        timeout: Time allowance for a message fulfilling the criteria
+
+    Returns:
+        tuple (bool, str) test status and debug output
+    """
+    status, debug = then_wait(msg_type, criteria_func, context, timeout)
+    return (not status, debug)
+
+@then('"{skill}" should not reply')
+def then_do_not_reply(context, skill):
+
+    def check_all_dialog(message):
+        msg_skill = message.data.get('meta').get('skill')
+        utt = message.data['utterance'].lower()
+        skill_responded = skill == msg_skill
+        debug_msg = ("{} responded with '{}'. \n".format(skill, utt)
+                     if skill_responded else '')
+        return (skill_responded, debug_msg)
+
+    passed, debug = then_wait_fail('speak', check_all_dialog, context)
+    if not passed:
+        assert_msg = debug
+        assert_msg += mycroft_responses(context)
+    assert passed, assert_msg or '{} responded'.format(skill)


### PR DESCRIPTION
Add then_wait_fail Voight Kampff step to Skill so that it's available during current test runs. 

Can be removed following the next release of Mycroft-core.