### PR TITLE
Fix Step vocab conflict and low confidence matching

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -225,10 +225,9 @@ class NewsSkill(CommonPlaySkill):
             match_level = CPSMatchLevel.ARTIST
         elif matched_feed['conf'] >= 0.5:
             match_level = CPSMatchLevel.CATEGORY
-        elif matched_feed['conf'] >= 0.3:
-            match_level = CPSMatchLevel.GENERIC
         else: 
             match_level = None
+            return match_level
         feed_data = { 'feed': matched_feed['key']}
 
         return (feed_title, match_level, feed_data)

--- a/test/behave/news.feature
+++ b/test/behave/news.feature
@@ -131,7 +131,7 @@ Feature: mycroft-news
   Scenario Outline: play music with names similar to news channels
     Given an english speaking user
      When the user says "<play some music>"
-     Then "NewsSkill" should not reply
+     Then "NewsSkill" should not respond
 
     Examples:
       | play some music |

--- a/test/behave/steps/news_steps.py
+++ b/test/behave/steps/news_steps.py
@@ -84,8 +84,10 @@ def then_wait_fail(msg_type, criteria_func, context, timeout=10):
     status, debug = then_wait(msg_type, criteria_func, context, timeout)
     return (not status, debug)
 
-@then('"{skill}" should not reply')
-def then_do_not_reply(context, skill):
+# NOTE: language here has been changed to avoid conflict with soon to be merged VK Step.
+# When this code is removed, change this back to "Skill should not reply"
+@then('"{skill}" should not respond')
+def then_do_not_respond(context, skill):
 
     def check_all_dialog(message):
         msg_skill = message.data.get('meta').get('skill')


### PR DESCRIPTION
Modified the Skill based Step vocab to avoid conflicts with same step that is in the process of being included in mycroft-core. Once it has been moved to a production release we can remove this workaround and restore the existing language.

Also stopped returning any data on low-confidence (<0.5) CPS matches. Turns out that returning a match level of None, will still play the data returned if nothing else can play. So on systems where no other CPS's are present, then the news will play something and the test fails.

Thanks to Ake for the debugging here.