### PR TITLE
auto detect station modules

### DIFF
--- a/stations/__init__.py
+++ b/stations/__init__.py
@@ -11,3 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from . import abc, gbp, tsf

--- a/stations/abc.py
+++ b/stations/abc.py
@@ -16,7 +16,7 @@ import pytz
 import requests
 from datetime import datetime
 
-def abc():
+def get_url():
     """Custom news fetcher for ABC News Australia briefing"""
     # Format template with (hour, day, month)
     url_temp = ('https://abcmedia.akamaized.net/news/audio/news-briefings/'

--- a/stations/gbp.py
+++ b/stations/gbp.py
@@ -1,0 +1,40 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import feedparser
+import re
+import requests
+
+from mycroft.util import LOG
+
+def get_url():
+    """Custom news fetcher for GBP news."""
+    feed = 'http://feeds.feedburner.com/gpbnews/GeorgiaRSS?format=xml'
+    data = feedparser.parse(feed)
+    next_link = None
+    for entry in data['entries']:
+        # Find the first mp3 link with "GPB {time} Headlines" in title
+        if 'GPB' in entry['title'] and 'Headlines' in entry['title']:
+            next_link = entry['links'][0]['href']
+            break
+    html = requests.get(next_link)
+    # Find the first mp3 link
+    # Note that the latest mp3 may not be news,
+    # but could be an interview, etc.
+    mp3_find = re.search(r'href="(?P<mp3>.+\.mp3)"'.encode(), html.content)
+    if mp3_find is None:
+        LOG.info("Could not find url for GBP News")
+        return None
+    url = mp3_find.group('mp3').decode('utf-8')
+    return url

--- a/stations/tsf.py
+++ b/stations/tsf.py
@@ -1,0 +1,37 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import requests
+from datetime import timedelta
+from pytz import timezone
+
+from mycroft.util.time import now_local
+
+def get_uri():
+    """Custom inews fetcher for TSF news."""
+    feed = ('https://www.tsf.pt/stream/audio/{year}/{month:02d}/'
+            'noticias/{day:02d}/not{hour:02d}.mp3')
+    uri = None
+    i = 0
+    status = 404
+    date = now_local(timezone('Portugal'))
+    while status != 200 and i < 5:
+        date -= timedelta(hours=i)
+        uri = feed.format(hour=date.hour, year=date.year,
+                          month=date.month, day=date.day)
+        status = requests.get(uri).status_code
+        i += 1
+    if status != 200:
+        return None
+    return uri

--- a/test/behave/news.feature
+++ b/test/behave/news.feature
@@ -109,7 +109,9 @@ Feature: mycroft-news
      | Play Fox News | Fox News |
      | Play PBS news | PBS Newshour |
      | Play YLE news | YLE |
+     | Play  ABC news | ABC |
      | Play  DLF news | DLF |
+     | Play  TSF news | TSF |
      | Play WDR news | WDR |
      | play news from bbc | BBC News |
      | Play news from ekot | Ekot |


### PR DESCRIPTION
All stations requiring a custom fetch station have been moved to the stations directory. 
Any new files added to this directory will now be automatically imported as modules.

I realised that none of the stations using the function call were included in the test suite so have also added these in. GBP has been left out as the feedburner for that station is currently broken.

