### PR TITLE
Bugfix for NPR query strings

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -145,6 +145,18 @@ def find_mime(url):
 
 
 def contains_html(file):
+    """Reads file and reports if a <html> tag is contained.
+
+    Makes a temporary copy of the file to prevent locking downloads in 
+    progress. This should not be considered a robust method of testing if a 
+    file is a HTML document, but sufficient for this purpose.
+
+        Args:
+            file (str): path of file
+
+        Returns:
+            bool: whether a <html> tag was found
+    """
     found_html = False
     tmp_file = '/tmp/mycroft-news-html-check'
     try:

--- a/__init__.py
+++ b/__init__.py
@@ -285,6 +285,9 @@ class NewsSkill(CommonPlaySkill):
                 # fall back to using the first link in the entry
                 media_url = data['entries'][0]['links'][0]['href']
         self.log.debug('Playing news from URL: {}'.format(media_url))
+        # TODO - check on temporary workaround and remove - see issue #87
+        if station_url.startswith('https://www.npr.org/'):
+            media_url = media_url.split('?')[0]
         return media_url
 
     @intent_file_handler("PlayTheNews.intent")

--- a/__init__.py
+++ b/__init__.py
@@ -151,11 +151,11 @@ def contains_html(file):
     progress. This should not be considered a robust method of testing if a 
     file is a HTML document, but sufficient for this purpose.
 
-        Args:
-            file (str): path of file
+    Args:
+        file (str): path of file
 
-        Returns:
-            bool: whether a <html> tag was found
+    Returns:
+        bool: whether a <html> tag was found
     """
     found_html = False
     tmp_file = '/tmp/mycroft-news-html-check'
@@ -204,14 +204,14 @@ class NewsSkill(CommonPlaySkill):
             matched_feed = { 'key': station_key, 'conf': 1.0 }        
 
         def match_feed_name(phrase, feed):
-            """ Determine confidence that a phrase requested a given feed.
+            """Determine confidence that a phrase requested a given feed.
 
-                    Args:
-                       phrase (str): utterance from the user
-                       feed (str): the station feed to match against
+            Args:
+                phrase (str): utterance from the user
+                feed (str): the station feed to match against
 
-                    Returns:
-                        tuple: feed being matched, confidence level
+            Returns:
+                tuple: feed being matched, confidence level
             """
             phrase = phrase.lower().replace("play", "")
             feed_short_name = feed.lower()
@@ -278,8 +278,13 @@ class NewsSkill(CommonPlaySkill):
         return feed_code
 
     def get_station(self):
-        """ Get station to play. Prioritise selected station, then custom url.
-        If neither exist then fallback to default station for country. """
+        """Get station user selected from settings or default station. 
+        
+        Fallback order:
+        1. User selected station
+        2. User defined custom url
+        3. Default station for country
+        """
         feed_code = self.settings.get("station", "not_set")
         station_url = self.settings.get("custom_url", "")
         if feed_code in FEEDS:


### PR DESCRIPTION
Full details in issue #87

As outlined in linked issue, this adds a temporary workaround for the NPR News feed stripping the query strings off the media url. This should not be done to all urls as these may be used for routing.

Also added a check on the downloaded file to see if it's HTML rather than audio. The url provided by NPR here (including query strings) returns a header.content-type of audio but the curl download is clearly a HTML error page. The check is not robust for most uses, but should catch clear HTML vs audio/media files.