### PR TITLE
Handle uri and status in CPS_send_status

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -410,12 +410,15 @@ class NewsSkill(CommonPlaySkill):
             self.CPS_send_status()
             return True
 
-    def CPS_send_status(self, artist='', track='', image=''):
+    def CPS_send_status(self, artist='', track='', image='',
+                        uri='', status=None, **kwargs):
+        """TODO remove in 20.08."""
         data = {'skill': self.name,
                 'artist': artist,
                 'track': track,
                 'image': image,
-                'status': None  # TODO Add status system
+                'status': status,
+                'uri': uri
                 }
         self.bus.emit(Message('play:status', data))
 


### PR DESCRIPTION
This caused an error when the CPS_play automatically sends uri in 20.2.5.

This is kept for backwards compatibility but can be removed from here in 20.08.