### PR TITLE
add specific vocab for 'breaking'

### DIFF
--- a/vocab/en-us/Latest.voc
+++ b/vocab/en-us/Latest.voc
@@ -2,3 +2,4 @@ latest
 morning
 current
 today
+breaking


### PR DESCRIPTION
"Breaking news" is currently a VK test phrase but "breaking" wasn't included in the Adapt vocab.

It passes sometimes on the weight of just "news" but will fail at random. This explicitly adds the word as accepted vocab.