### PR TITLE
Remove VK step now included in core v20.08

### DIFF
--- a/test/behave/news.feature
+++ b/test/behave/news.feature
@@ -131,7 +131,7 @@ Feature: mycroft-news
   Scenario Outline: play music with names similar to news channels
     Given an english speaking user
      When the user says "<play some music>"
-     Then "NewsSkill" should not respond
+     Then "NewsSkill" should not reply
 
     Examples:
       | play some music |

--- a/test/behave/steps/news_steps.py
+++ b/test/behave/steps/news_steps.py
@@ -66,39 +66,3 @@ def then_playback_stop(context):
 @then('"mycroft-news" should pause playing')
 def then_playback_pause(context):
     wait_for_service_message(context, 'pause')
-
-# TODO remove from Skill once included in Mycroft-core
-def then_wait_fail(msg_type, criteria_func, context, timeout=10):
-    """Wait for a specified time, failing if criteria is fulfilled.
-
-    Arguments:
-        msg_type: message type to watch
-        criteria_func: Function to determine if a message fulfilling the
-                       test case has been found.
-        context: behave context
-        timeout: Time allowance for a message fulfilling the criteria
-
-    Returns:
-        tuple (bool, str) test status and debug output
-    """
-    status, debug = then_wait(msg_type, criteria_func, context, timeout)
-    return (not status, debug)
-
-# NOTE: language here has been changed to avoid conflict with soon to be merged VK Step.
-# When this code is removed, change this back to "Skill should not reply"
-@then('"{skill}" should not respond')
-def then_do_not_respond(context, skill):
-
-    def check_all_dialog(message):
-        msg_skill = message.data.get('meta').get('skill')
-        utt = message.data['utterance'].lower()
-        skill_responded = skill == msg_skill
-        debug_msg = ("{} responded with '{}'. \n".format(skill, utt)
-                     if skill_responded else '')
-        return (skill_responded, debug_msg)
-
-    passed, debug = then_wait_fail('speak', check_all_dialog, context)
-    if not passed:
-        assert_msg = debug
-        assert_msg += mycroft_responses(context)
-    assert passed, assert_msg or '{} responded'.format(skill)


### PR DESCRIPTION
Removes the wait_for_message method and custom "skill should not respond" Step as these have been added to Mycroft-core in v20.08.