### PR TITLE
Bump feedparser requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-feedparser>=6.0.0
+feedparser~=6.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-feedparser==5.2.1
+feedparser>=6.0.0


### PR DESCRIPTION
To support Python; 3.6, 3.7, 3.8 and 3.9