### PR TITLE
Bugfix/bad matching

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -135,6 +135,11 @@ FEEDS = {
 # If feed URL ends in specific filetype, just play it
 DIRECT_PLAY_FILETYPES = ['.mp3']
 
+# Minimum confidence levels
+CONF_EXACT_MATCH = 0.9
+CONF_LIKELY_MATCH = 0.7
+CONF_GENERIC_MATCH = 0.6
+
 
 def find_mime(url):
     mime = 'audio/mpeg'
@@ -193,11 +198,11 @@ class NewsSkill(CommonPlaySkill):
         matched_feed = { 'key': None, 'conf': 0.0 }
 
         # Remove "the" as it matches too well will "other"
-        search_phrase = phrase.lower().replace('the', '')
+        search_phrase = phrase.lower().replace('the', '').strip()
         
         # Catch any short explicit phrases eg "play the news"
         news_phrases = self.translate_list("PlayTheNews") or []
-        if search_phrase.strip() in news_phrases:
+        if search_phrase in news_phrases:
             station_key = self.settings.get("station", "not_set")
             if station_key == "not_set":
                 station_key = self.get_default_station()
@@ -213,17 +218,17 @@ class NewsSkill(CommonPlaySkill):
             Returns:
                 tuple: feed being matched, confidence level
             """
-            phrase = phrase.lower().replace("play", "")
+            phrase = phrase.lower().replace("play", "").strip()
             feed_short_name = feed.lower()
+            feed_long_name = FEEDS[feed][0].lower()
             short_name_confidence = fuzzy_match(phrase, feed_short_name)
-            long_name_confidence = fuzzy_match(phrase, FEEDS[feed][0].lower())
+            long_name_confidence = fuzzy_match(phrase, feed_long_name)
             # Test with "News" added in case user only says acronym eg "ABC".
             # As it is short it may not provide a high match confidence.
             news_keyword = self.translate("OnlyNews").lower()
             modified_short_name = "{} {}".format(feed_short_name, news_keyword)
             variation_confidence = fuzzy_match(phrase, modified_short_name)
-            key_confidence = 0.6 if news_keyword in phrase and feed_short_name in phrase else 0.0
-
+            key_confidence = CONF_GENERIC_MATCH if news_keyword in phrase and feed_short_name in phrase else 0.0
 
             conf = max((short_name_confidence, long_name_confidence,
                         variation_confidence, key_confidence))
@@ -244,21 +249,20 @@ class NewsSkill(CommonPlaySkill):
                 matched_feed['key'] = self.alt_feed_names[name]
             
         # If no match but utterance contains news, return low confidence level
-        if matched_feed['conf'] == 0.0 and self.voc_match(search_phrase, "News"):
-            matched_feed = { 'key': None, 'conf': 0.5 }
+        if matched_feed['conf'] < CONF_GENERIC_MATCH and self.voc_match(search_phrase, "News"):
+            matched_feed = { 'key': self.get_default_station(), 'conf': CONF_GENERIC_MATCH }
 
         feed_title = FEEDS[matched_feed['key']][0]
-        if matched_feed['conf'] >= 0.9:
+        if matched_feed['conf'] >= CONF_EXACT_MATCH:
             match_level = CPSMatchLevel.EXACT  
-        elif matched_feed['conf'] >= 0.7:
+        elif matched_feed['conf'] >= CONF_LIKELY_MATCH:
             match_level = CPSMatchLevel.ARTIST
-        elif matched_feed['conf'] >= 0.5:
+        elif matched_feed['conf'] >= CONF_GENERIC_MATCH:
             match_level = CPSMatchLevel.CATEGORY
         else: 
             match_level = None
             return match_level
-        feed_data = { 'feed': matched_feed['key']}
-
+        feed_data = {'feed': matched_feed['key']}
         return (feed_title, match_level, feed_data)
 
     def CPS_start(self, phrase, data):

--- a/__init__.py
+++ b/__init__.py
@@ -199,6 +199,10 @@ class NewsSkill(CommonPlaySkill):
 
         # Remove "the" as it matches too well will "other"
         search_phrase = phrase.lower().replace('the', '').strip()
+
+        if not self.voc_match(search_phrase, "News"):
+            # User not asking for the news - do not match.
+            return
         
         # Catch any short explicit phrases eg "play the news"
         news_phrases = self.translate_list("PlayTheNews") or []

--- a/test/behave/news.feature
+++ b/test/behave/news.feature
@@ -1,10 +1,12 @@
 Feature: mycroft-news
 
-  Scenario Outline: what's the news
+  Background:
     Given an english speaking user
-    And nothing is playing
-      When the user says "<what's the news>"
-      Then "mycroft-news" should reply with dialog from "news.dialog"
+
+  Scenario Outline: what's the news
+    Given nothing is playing
+    When the user says "<what's the news>"
+    Then "mycroft-news" should reply with dialog from "news.dialog"
 
    Examples: What's the news - standard intent
      | what's the news |
@@ -36,10 +38,9 @@ Feature: mycroft-news
      | other news |
 
   Scenario Outline: Play the news using Common Play Framework
-    Given an english speaking user
-    And nothing is playing
-      When the user says "<play the news>"
-      Then "mycroft-playback-control" should reply with dialog from "news.dialog"
+    Given nothing is playing
+    When the user says "<play the news>"
+    Then "mycroft-playback-control" should reply with dialog from "news.dialog"
 
    Examples: play the news
      | play the news |
@@ -55,10 +56,9 @@ Feature: mycroft-news
      | play the news again |
 
   Scenario Outline: stop news playback
-    Given an english speaking user
-      And news is playing
-      When the user says "<stop the news>"
-      Then "mycroft-news" should stop playing
+    Given news is playing
+    When the user says "<stop the news>"
+    Then "mycroft-news" should stop playing
 
    Examples: stop news playback
      | stop the news |
@@ -68,10 +68,9 @@ Feature: mycroft-news
   @xfail
   # Jira MS-108 https://mycroft.atlassian.net/browse/MS-108
   Scenario Outline: Failing stop news playback
-    Given an english speaking user
-      And news is playing
-      When the user says "<stop the news>"
-      Then "mycroft-news" should stop playing
+    Given news is playing
+    When the user says "<stop the news>"
+    Then "mycroft-news" should stop playing
 
    Examples: stop news playback
      | stop the news |
@@ -87,19 +86,17 @@ Feature: mycroft-news
      | silence |
 
   Scenario Outline: pause news playback
-    Given an english speaking user
-      When the user says "<pause the news>"
-      Then "mycroft-news" should pause playing
+    When the user says "<pause the news>"
+    Then "mycroft-news" should pause playing
 
    Examples: pause news playback
      | pause the news |
      | pause |
 
   Scenario Outline: play a specific news channel
-    Given an english speaking user
-      When the user says "<play a specific news channel>"
-      Then "mycroft-playback-control" should reply with dialog from "just.one.moment.dialog"
-      Then mycroft reply should contain "<specified channel>"
+    When the user says "<play a specific news channel>"
+    Then "mycroft-playback-control" should reply with dialog from "just.one.moment.dialog"
+    Then mycroft reply should contain "<specified channel>"
 
    Examples: play specific news channel
      | play a specific news channel | specified channel |
@@ -118,9 +115,8 @@ Feature: mycroft-news
 
   @xfail
   Scenario Outline: give me the news from channel
-    Given an english speaking user
-      When the user says "<give me news from a specific channel>"
-      Then mycroft reply should contain "<specified channel>"
+    When the user says "<give me news from a specific channel>"
+    Then mycroft reply should contain "<specified channel>"
 
    Examples:
      | give me news from a specific channel | specified channel |
@@ -131,15 +127,11 @@ Feature: mycroft-news
      | what are the headlines from WDR | WDR |
 
   Scenario Outline: play music with names similar to news channels
-    Given an english speaking user
-     When the user says "<play some music>"
-     Then "NewsSkill" should not reply
+    When the user says "<play some music>"
+    Then "NewsSkill" should not reply
 
     Examples:
       | play some music |
-      | what time is it |
-      | what's the weather |
-      | cancel timer |
       | play metallica |
       | play 1live on tunein |
       | play sunshine on tunein |
@@ -149,3 +141,22 @@ Feature: mycroft-news
       | play the song skinamarinky dinky dink |
       | play the song python programming |
       | play the song covid-19 |
+
+  Scenario Outline: play radio from stations not defined in News Skill
+    When the user says "<play some radio station>"
+    Then "NewsSkill" should not reply
+
+    Examples:
+      | play some radio station |
+      | play kuow |
+      | play kuow radio |
+
+  Scenario Outline: Utterances unrelated to the News Skill
+    When the user says "<something unrelated to this skill>"
+    Then "NewsSkill" should not reply
+
+    Examples:
+      | something unrelated to this skill |
+      | what time is it |
+      | what's the weather |
+      | cancel timer |

--- a/test/behave/news.feature
+++ b/test/behave/news.feature
@@ -12,27 +12,20 @@ Feature: mycroft-news
      | what's the news |
      | what's the news |
      | what's new |
-     | what's the news |
      | what's the latest news |
      | let's hear the news |
      | what's this hour's news |
      | give me the news |
      | news |
      | news briefing |
+     | breaking news |
      | brief me |
      | brief me on the headlines |
      | give me the headlines |
-     | give me the breaking news |
      | what's the breaking news |
-     | breaking news |
      | give me the news updates |
-     | what's today's news |
      | what's today's briefing |
      | what are today's headlines |
-     | what's today's headlines |
-     | tell me the news |
-     | tell me today's headlines |
-     | tell me the headlines |
      | tell me what's happening |
      | what's happening |
      | other news |

--- a/vocab/en-us/News.voc
+++ b/vocab/en-us/News.voc
@@ -1,4 +1,5 @@
 news
+news again
 briefing
 bulletin
 headlines

--- a/vocab/en-us/News.voc
+++ b/vocab/en-us/News.voc
@@ -4,3 +4,4 @@ briefing
 bulletin
 headlines
 happening
+latest

--- a/vocab/en-us/PlayTheNews.intent
+++ b/vocab/en-us/PlayTheNews.intent
@@ -1,4 +1,4 @@
-news (briefing|)
+news (again|briefing|)
 (what is|what's) new
 brief me
 (what's|what is) today's (news|briefing)


### PR DESCRIPTION
#### Description
This further improves the CPS matching logic for News stations.
- Most importantly it no longer attempts to match at all if there is no "News" vocab present in the search phrase eg "news", "briefing", "headlines" etc.
- It also increases the minimum required fuzzy_match confidence from 0.5 > 0.6

New tests added.

Fixes #100 

#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements