### PR TITLE
Fix stop vocab only working for common play usage

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -338,7 +338,7 @@ class NewsSkill(CommonPlaySkill):
             self.stop()
             return True  # consume this phrase
         else:
-            self.log.info("NewsSkill:Converse confused by %s" % (utterances[0],))
+            self.log.info("NewsSkill:Converse confused by %s" % (utterances,))
 
         return False  # don't consume this phrase
 

--- a/__init__.py
+++ b/__init__.py
@@ -337,8 +337,6 @@ class NewsSkill(CommonPlaySkill):
         if utterances and self.voc_match(utterances[0], "Stop"):
             self.stop()
             return True  # consume this phrase
-        else:
-            self.log.info("NewsSkill:Converse confused by %s" % (utterances,))
 
         return False  # don't consume this phrase
 

--- a/__init__.py
+++ b/__init__.py
@@ -413,6 +413,7 @@ class NewsSkill(CommonPlaySkill):
         # Stop download process if it's running.
         if self.curl:
             self.log.info("Stopping the News Skill playback")
+            self.audioservice.stop()
             try:
                 self.curl.kill()
                 self.curl.communicate()

--- a/__init__.py
+++ b/__init__.py
@@ -332,6 +332,16 @@ class NewsSkill(CommonPlaySkill):
             media_url = media_url.split('?')[0]
         return media_url
 
+    def converse(self, utterances, lang="en-us"):
+        """if playing see if user wants to quit"""
+        if utterances and self.voc_match(utterances[0], "Stop"):
+            self.stop()
+            return True  # consume this phrase
+        else:
+            self.log.info("NewsSkill:Converse confused by %s" % (utterances[0],))
+
+        return False  # don't consume this phrase
+
     @intent_file_handler("PlayTheNews.intent")
     def handle_latest_news_alt(self, message):
         # Capture some alternative ways of requesting the news via Padatious

--- a/test/behave/news.feature
+++ b/test/behave/news.feature
@@ -57,6 +57,15 @@ Feature: mycroft-news
      | stop the news |
      | stop |
      | stop playing |
+     | quit |
+     | end |
+     | turn it off |
+     | turn off news |
+     | turn off music |
+     | shut it off |
+     | shut up |
+     | be quiet |
+     | end playback |
 
   @xfail
   # Jira MS-108 https://mycroft.atlassian.net/browse/MS-108
@@ -67,15 +76,8 @@ Feature: mycroft-news
 
    Examples: stop news playback
      | stop the news |
-     | quit |
-     | end |
      | turn it off |
-     | turn off news |
-     | turn off music |
-     | shut it off |
      | shut up |
-     | be quiet |
-     | end playback |
      | silence |
 
   Scenario Outline: pause news playback

--- a/vocab/en-us/Stop.voc
+++ b/vocab/en-us/Stop.voc
@@ -4,7 +4,6 @@ end
 stop
 shut
 off
-turn
 quiet
 terminate
 abort

--- a/vocab/en-us/Stop.voc
+++ b/vocab/en-us/Stop.voc
@@ -1,0 +1,10 @@
+silence
+quit
+end
+stop
+shut
+off
+turn
+quiet
+terminate
+abort


### PR DESCRIPTION
#### Description
An alternative to PR #108 - this adds Skill specific "stop" vocab that is only registered when the Skill is performing it's own local playback ie not through the Common Play Framework. 

As the intent is only active while the News Skill is playing, it is quite liberal with it's matching at the moment.

This also calls `audioservice.stop()` to allow the VK tests to pass. Remaining @xfail's are caused by the Timer Skill matching on Stop utterances when it has no alarms set or expired.

I don't believe this local vocab is a long term solution but we first need better contextual awareness and a unified playback system.

#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
VK tests
