### PR TITLE
Fix name of GPB allowing settings to work

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -61,8 +61,8 @@ def tsf():
     return uri
 
 
-def gbp():
-    """Custom news fetcher for GBP news."""
+def gpb():
+    """Custom news fetcher for GPB news."""
     feed = 'http://feeds.feedburner.com/gpbnews/GeorgiaRSS?format=xml'
     data = feedparser.parse(feed)
     next_link = None
@@ -122,7 +122,7 @@ FEEDS = {
             image_path('WDR')),
     'YLE': ('YLE', 'https://feeds.yle.fi/areena/v1/series/1-1440981.rss',
             image_path('Yle.png')),
-    "GBP": ("Georgia Public Radio", gbp, None),
+    "GPB": ("Georgia Public Radio", gpb, None),
     "RDP": ("RDP Africa", "http://www.rtp.pt//play/itunes/5442", None),
     "RNE": ("National Spanish Radio",
             "http://api.rtve.es/api/programas/36019/audios.rs", None),


### PR DESCRIPTION
#### Description
The acronym for "Georgia Public Broadcaster" radio was correct in the settings definition but incorrect in the Skill code. GBP instead of the correct GPB. 

This fixes all references to that acronym, however I just remembered that the feed itself is still broken - see issue #86 

We haven't removed it from the settings because of the user settings wipe issue.

#### Type of PR
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements
