### PR TITLE
Add theme dict and mimetype for radio for guiplayer service

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -385,7 +385,12 @@ class NewsSkill(CommonPlaySkill):
             wait_while_speaking()
             # Begin the news stream
             self.log.info('Feed: {}'.format(feed))
-            self.CPS_play(('file://' + self.STREAM, mime))
+            if self.gui.connected:
+                mime = "type/radio"
+                theme = dict(textColor="white", seekBackgroundColor="#BE1617", spectrumColor="#91D3F8", cardBackgroundColor="#5F0B0C")
+                self.CPS_play(('file://' + self.STREAM, mime, theme))
+            else:
+                self.CPS_play(('file://' + self.STREAM, mime))
             self.CPS_send_status(image=image or image_path('generic.png'),
                                  track=self.now_playing)
             self.last_message = (True, message)


### PR DESCRIPTION
#### Description
- Add support to send a dict containing the color scheme for the theme as per the figma
- Add correct mime type for GUI Player service so it can display the correct qml

#### Type of PR
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
requires: https://github.com/MycroftAI/plugin-playback-gui-player/pull/3
requires: https://github.com/MycroftAI/skill-playback-control/pull/49

#### CLA
- [x] Yes