### PR TITLE
Fix TypeError - check length of list

### DIFF
--- a/stations/station.py
+++ b/stations/station.py
@@ -143,7 +143,7 @@ def create_custom_station(station_url):
 
     NOTE: it cannot be a FetcherStation because you can't define the fetching function.
     """
-    is_rss_feed = feedparser.parse(station_url).entries > 0
+    is_rss_feed = len(feedparser.parse(station_url).entries) > 0
     if is_rss_feed:
         clazz = RSSStation
     else:


### PR DESCRIPTION
#### Description
Fixes #123 - if using a custom news url the RSS checker was incorrectly comparing an integer to the list itself instead of the length of that list.

#### Type of PR
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Add a custom url to your Skill settings and see the Skill fail to load it.

#### CLA
- [x] Yes